### PR TITLE
[FIX] im_livechat: prevent crash and stale window when leaving session

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -271,6 +271,7 @@ class LivechatController(http.Controller):
             return
         domain = [("channel_id", "=", channel_sudo.id), ("is_self", "=", True)]
         member = request.env["discuss.channel.member"].search(domain)
-        # sudo: discuss.channel.rtc.session - member of current user can leave call
-        member.sudo()._rtc_leave_call()
+        if member:
+            # sudo: discuss.channel.rtc.session - member of current user can leave call
+            member.sudo()._rtc_leave_call()
         channel_sudo._close_livechat_session()

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -142,15 +142,17 @@ export class LivechatService {
      */
     async leaveSession({ notifyServer = true } = {}) {
         const session = JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? "{}");
-        try {
-            if (session?.uuid && notifyServer) {
-                this.busService.deleteChannel(session.uuid);
-                await this.rpc("/im_livechat/visitor_leave_session", { uuid: session.uuid });
-            }
-        } finally {
-            expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
-            this.state = SESSION_STATE.NONE;
-            this.sessionInitialized = false;
+        // Clear the saved session synchronously, before notifying the server.
+        // Otherwise, if the visitor leaves the page (navigation, tab/browser
+        // close) before the `visitor_leave_session` request settles, the
+        // request is aborted, the cleanup below never runs and the stale
+        // session is restored on the next page load.
+        expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
+        this.state = SESSION_STATE.NONE;
+        this.sessionInitialized = false;
+        if (session?.uuid && notifyServer) {
+            this.busService.deleteChannel(session.uuid);
+            await this.rpc("/im_livechat/visitor_leave_session", { uuid: session.uuid });
         }
     }
 

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_message
 from . import test_upload_attachment
 from . import test_res_users
 from . import test_session_history
+from . import test_visitor_leave_session

--- a/addons/im_livechat/tests/test_visitor_leave_session.py
+++ b/addons/im_livechat/tests/test_visitor_leave_session.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestVisitorLeaveSession(HttpCase):
+    def test_leave_session_without_guest_context(self):
+        """Leaving a livechat session while the visitor's guest context is no
+        longer available (e.g. the ``dgid`` cookie expired, was cleared, or is
+        blocked as a third-party cookie) must not raise.
+
+        In that situation the ``is_self`` member lookup returns an empty
+        recordset; the route must not call ``_rtc_leave_call`` on it (which
+        asserts a singleton) and must still close the livechat session.
+        """
+        self.authenticate(None, None)
+        operator = self.env["res.users"].create({"name": "Operator", "login": "operator_leave"})
+        self.env["bus.presence"].create({"user_id": operator.id, "status": "online"})
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Test Leave Channel", "user_ids": [operator.id]}
+        )
+        channel_info = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {"anonymous_name": "Visitor", "channel_id": livechat_channel.id, "persisted": True},
+        )
+        channel = self.env["discuss.channel"].browse(channel_info["id"])
+        self.assertTrue(channel.livechat_active)
+        # Simulate the loss of the guest context: drop the guest cookie so the
+        # next request cannot resolve the current guest, leaving the member
+        # lookup empty.
+        self.opener.cookies.pop("dgid", None)
+        # Must not raise "Expected singleton: discuss.channel.member()".
+        self.make_jsonrpc_request(
+            "/im_livechat/visitor_leave_session", {"uuid": channel_info["uuid"]}
+        )
+        # The session must still be closed even though there was no member to
+        # leave the RTC call for.
+        self.assertFalse(channel.livechat_active)


### PR DESCRIPTION
> Backport / mirror of upstream PR odoo/odoo#268509 (chưa được Odoo review).

### Description

Closing a livechat conversation triggers two issues when the visitor's
guest context is no longer available (the `dgid` cookie expired, was
cleared, is blocked as a third-party cookie on an embedded livechat, or
the visitor is in private browsing).

**1. HTTP 500 `Expected singleton: discuss.channel.member()`**

`/im_livechat/visitor_leave_session` resolves the visitor's
`discuss.channel.member` through the `is_self` domain and calls
`_rtc_leave_call()` on the result. Without a guest context the lookup
returns an empty recordset, so `_rtc_leave_call()` hits `ensure_one()`
and raises. The exception also stops `_close_livechat_session()` from
running, so the conversation stays open server-side.

**2. The chat window reopens after being closed**

`LivechatService.leaveSession` removed the saved session from the storage
in a `finally` block, after awaiting the `visitor_leave_session` RPC. When
the visitor leaves the page right after closing the chat, the in-flight
request is aborted and the page is torn down before the `finally` runs, so
the saved session is restored on the next page load.

### Fix

- `visitor_leave_session`: only call `_rtc_leave_call()` when a member is
  found, and always close the livechat session afterwards.
- `LivechatService.leaveSession`: clear the saved session synchronously,
  before notifying the server, so the cleanup no longer depends on the RPC
  settling.

A regression test (`test_leave_session_without_guest_context`) covers the
server-side fix.

---
Upstream PR: https://github.com/odoo/odoo/pull/268509
