### PR TITLE
[FIX] website: deflake edit_menus tour when menu items overflow the dialog

### DIFF
--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -398,6 +398,20 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
         run: () => {}, // It's a check.
     },
     {
+        // The drag helper takes viewport coordinates without scrolling the
+        // target into view first. The rows this tour drags are appended at the
+        // bottom of the list, so when installed modules add enough menu items,
+        // those rows overflow the dialog body and the drags silently miss.
+        content: "Scroll to the bottom of the menu editor so the rows to drag are visible",
+        trigger: ".oe_menu_editor li:contains('new_nested_menu')",
+        run: function () {
+            const scrollableEl = this.$anchor[0].closest(".modal-body");
+            if (scrollableEl) {
+                scrollableEl.scrollTop = scrollableEl.scrollHeight;
+            }
+        },
+    },
+    {
         content: "Nest 'new_nested_menu' under 'new_menu'",
         trigger: ".oe_menu_editor li:contains('new_nested_menu') .fa-bars",
         run: "drag_and_drop_native .oe_menu_editor li:contains('new_menu') .form-control",


### PR DESCRIPTION


The final drag section of the edit_menus tour operates on rows the tour itself appends at the bottom of the menu editor list. The drag helper (drag_and_drop_native) computes viewport coordinates from getBoundingClientRect() without scrolling the target into view first, so when installed modules add enough top-level menu items (e.g. to_runbot adds 'Runbot' and 'Runbot Standalone'), the rows to drag overflow the fixed-height dialog body (~490px at 1366x768) and the pointer events silently miss, failing the tour at:

    Check if 'nested_menu' and 'Modnar !!' is nested under 'new_menu'

Scroll the dialog body to the bottom right before the drag section so the dragged rows are always within view. Reproduced and verified on a database where the tour-time list reaches 14-18 rows: failed 6/6 before, passes 3/3 (14 rows), and still passes at 18 and 10 rows after the fix.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
