### PR TITLE
[FIX] point_of_sale: write the country id, not the record, in tests c…

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -156,7 +156,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             'country_id': cls.env['res.country'].create({
                 'name': 'PoS Land',
                 'code': 'WOW',
-            }),
+            }).id,
         })
 
         # Set basic defaults


### PR DESCRIPTION
`https://github.com/odoo/odoo/pull/282387`

TestPoSCommon.setUpClass writes the company country as a res.country record instead of its id. The ORM tolerates it, but every res.company write override that inspects vals['country_id'] then receives a record where any other caller passes an id or False. An override comparing that value against an id trips the reflected BaseModel.__eq__, which emits an "unsupported operand type(s)" py.warnings for every test class derived from TestPoSCommon, and the comparison silently evaluates to False.

Write the id, as done everywhere else in the test suite.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
